### PR TITLE
Update for recent Mongo

### DIFF
--- a/src/Mandango/Connection.php
+++ b/src/Mandango/Connection.php
@@ -189,7 +189,7 @@ class Connection implements ConnectionInterface
                     $this->mongo->setLogDefault($this->logDefault);
                 }
             } else {
-                $this->mongo = new \Mongo($this->server, $this->options);
+                $this->mongo = new \MongoClient($this->server, $this->options);
             }
         }
 

--- a/src/Mandango/Logger/LoggableMongoCursor.php
+++ b/src/Mandango/Logger/LoggableMongoCursor.php
@@ -180,12 +180,12 @@ class LoggableMongoCursor extends \MongoCursor
                 $log['snapshot'] = 1;
             }
             $log['explain'] = array(
-                'nscanned'        => $explain['nscanned'],
-                'nscannedObjects' => $explain['nscannedObjects'],
-                'n'               => $explain['n'],
-                'indexBounds'     => $explain['indexBounds'],
+                'nscanned'        => $explain['executionStats']['totalKeysExamined'],
+                'nscannedObjects' => $explain['executionStats']['totalDocsExamined'],
+                'n'               => $explain['executionStats']['nReturned'],
+                'indexBounds'     => isset($explain['indexBounds']) ? $explain['indexBounds'] : null,
             );
-            $log['time'] = $explain['millis'];
+            $log['time'] = $explain['executionStats']['executionTimeMillis'];
 
             $this->log($log);
         }

--- a/src/Mandango/Logger/LoggableMongoGridFS.php
+++ b/src/Mandango/Logger/LoggableMongoGridFS.php
@@ -297,7 +297,7 @@ class LoggableMongoGridFS extends \MongoGridFS
     /*
      * findOne.
      */
-    public function findOne($query = array(), $fields = array())
+    public function findOne($query = null, $fields = null, array $options = null)
     {
         $cursor = new LoggableMongoGridFSCursor($this, $query, $fields, 'findOne');
         $cursor->limit(-1);

--- a/tests/Mandango/Tests/ConnectionTest.php
+++ b/tests/Mandango/Tests/ConnectionTest.php
@@ -22,7 +22,7 @@ class ConnectionTest extends TestCase
         $mongo   = $connection->getMongo();
         $mongoDB = $connection->getMongoDB();
 
-        $this->assertInstanceOf('\Mongo', $mongo);
+        $this->assertInstanceOf('\MongoClient', $mongo);
         $this->assertInstanceOf('\MongoDB', $mongoDB);
         $this->assertSame($this->dbName, $mongoDB->__toString());
 


### PR DESCRIPTION
Applies updates that allow Mandango to work with MongoDB >= 2.6, and removes some deprecations that came up.

Tests all pass, woo!

(Tested on PHP 5.5)
