### PR TITLE
in_array can return incorrect result

### DIFF
--- a/src/Mandango/Query.php
+++ b/src/Mandango/Query.php
@@ -620,7 +620,7 @@ abstract class Query implements \Countable, \IteratorAggregate
                 continue;
             }
             foreach ($queryParts as $type => $data) {
-                if (!in_array($type, array('$in', '$nin'))) {
+                if (!in_array($type, array('$in', '$nin'), true)) {
                     continue;
                 }
 


### PR DESCRIPTION
``` php
$type = 0;

$result = in_array($type, array('$in', '$nin'));

var_dump($result);//will be return "bool(true)"
```
